### PR TITLE
Fix multisite localized URL discovery

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -232,13 +232,27 @@ class Generator
     private function getUrls(): Collection
     {
         return collect()
-            ->merge(collect(Craft::$app->getSites()->getAllSites())->map(fn(Site $site) => $site->baseUrl)->filter())
-            ->merge(collect(Entry::findAll())->map(fn(Entry $entry) => $entry->getUrl()))
-            ->merge(collect(Category::findAll())->map(fn(Category $category) => $category->getUrl()))
-            ->merge(collect(User::findAll())->map(fn(User $user) => $user->getUrl()))
+            ->merge($this->getSiteBaseUrls())
+            ->merge($this->getElementUrls(Entry::class))
+            ->merge($this->getElementUrls(Category::class))
+            ->merge($this->getElementUrls(User::class))
             ->filter()
             ->unique()
             ->map(fn(string $url) => new Url($url, $this->destination, $this->directoryIndex));
+    }
+
+    private function getSiteBaseUrls(): Collection
+    {
+        return collect(Craft::$app->getSites()->getAllSites())
+            ->map(fn(Site $site) => $site->baseUrl)
+            ->filter();
+    }
+
+    private function getElementUrls(string $elementClass): Collection
+    {
+        return collect($elementClass::find()->site('*')->all())
+            ->map(fn(object $element) => $element->getUrl())
+            ->filter();
     }
 
     private function generatePage(Url $url): array

--- a/src/generate-page.php
+++ b/src/generate-page.php
@@ -4,7 +4,16 @@ declare(strict_types=1);
 
 use craft\web\View;
 
-[$_, $url, $siteBaseUrlsJson, $newBaseUrl, $root, $webroot] = $argv;
+/** @var array<int, string> $arguments */
+$arguments = $_SERVER['argv'] ?? [];
+
+if (count($arguments) < 6) {
+    fwrite(STDERR, "Missing required arguments.\n");
+
+    exit(1);
+}
+
+[$_, $url, $siteBaseUrlsJson, $newBaseUrl, $root, $webroot] = $arguments;
 $siteBaseUrls = json_decode($siteBaseUrlsJson, true);
 
 $https = parse_url($url, PHP_URL_SCHEME) === 'https';

--- a/tests/Feature/GeneratorTest.php
+++ b/tests/Feature/GeneratorTest.php
@@ -180,6 +180,75 @@ it('accepts a custom URL collection via the urls setter', function () {
     expect($generator)->toBeInstanceOf(Generator::class);
 });
 
+it('queries localized element urls across all sites', function () {
+    $query = new class([
+        new class('https://example.com/news/article-1') {
+            public function __construct(
+                private string $url,
+            ) {
+            }
+
+            public function getUrl(): string
+            {
+                return $this->url;
+            }
+        },
+        new class('https://example.com/fr/news/article-1') {
+            public function __construct(
+                private string $url,
+            ) {
+            }
+
+            public function getUrl(): string
+            {
+                return $this->url;
+            }
+        },
+    ]) {
+        public array $siteCalls = [];
+
+        public function __construct(
+            private array $elements,
+        ) {
+        }
+
+        public function site(mixed $site): self
+        {
+            $this->siteCalls[] = $site;
+
+            return $this;
+        }
+
+        public function all(): array
+        {
+            return $this->elements;
+        }
+    };
+
+    $elementClass = new class {
+        public static object $query;
+
+        public static function find(): object
+        {
+            return self::$query;
+        }
+    };
+
+    $elementClassName = $elementClass::class;
+    $elementClassName::$query = $query;
+
+    $generator = Generator::new();
+
+    $method = new ReflectionMethod(Generator::class, 'getElementUrls');
+    $urls = $method->invoke($generator, $elementClassName);
+
+    expect($query->siteCalls)->toBe(['*'])
+        ->and($urls->all())->toBe([
+            'https://example.com/news/article-1',
+            'https://example.com/fr/news/article-1',
+        ]);
+});
+
 it('throws when concurrency is greater than 1 without spatie/fork', function () {
     // spatie/fork IS installed as a dev dependency, so this test verifies
     // that concurrency > 1 works without throwing


### PR DESCRIPTION
## Summary
- query entry, category, and user URLs across all sites during URL discovery
- preserve site homepage/base URL collection separately from element URL collection
- add a regression test for localized multisite URLs and guard worker argv parsing for phpstan

Fixes #4.